### PR TITLE
fix swarming doc for creating Oauth 2.0 Client Id

### DIFF
--- a/appengine/swarming/README.md
+++ b/appengine/swarming/README.md
@@ -18,6 +18,7 @@ Swarming is purely a task scheduler service.
     *   IAM & Admin
         *   Click `Add Member` and add someone else so you can safely be hit by a
             bus.
+    *   API Manager
         *   Create a new "Oauth 2.0 Client Id" of type "web application".  Make sure
             `https://<appid>.appspot.com` is an authorized JavaScript origin
             and `https://<appid>.appspot.com/oauth2callback` is an authorized


### PR DESCRIPTION
* The current doc is misleading (IAM & Admin), and a user will be
hard to find the right place for creating this Oauth Id.