### PR TITLE
Example .isolate and text description don't match

### DIFF
--- a/appengine/isolate/doc/client/Isolate-User-Guide.md
+++ b/appengine/isolate/doc/client/Isolate-User-Guide.md
@@ -47,7 +47,7 @@ only on Windows and the command there is different:
       },
     }],
 
-    ['OS=="android"', {
+    ['OS=="windows"', {
       'variables': {
         'command': [
           'setup_env.py',


### PR DESCRIPTION
The description says Windows but the example file says "android" and has no mention of windows.